### PR TITLE
Fix: Correct dashboard stats file path

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultStatsPath = "/var/lib/astra_socks_eliza/stats.json"
+	defaultStatsPath = "./stats.json"
 	defaultPort      = "8080"
 )
 


### PR DESCRIPTION
The dashboard was configured to read metrics from a hardcoded absolute path (`/var/lib/astra_socks_eliza/stats.json`), which caused it to fail when the file was not present at that location.

This change updates the default path to a relative one (`./stats.json`), aligning it with the main proxy application's output. This allows the dashboard to find the statistics file when run from the project's root directory, resolving the issue of metrics not being displayed.